### PR TITLE
Change window's set_layout to run_command('set_layout')

### DIFF
--- a/origami.py
+++ b/origami.py
@@ -54,13 +54,13 @@ def fixed_set_layout(window, layout):
 	#A bug was introduced in Sublime Text 3, sometime before 3053, in that it
 	#changes the active group to 0 when the layout is changed. Annoying.
 	active_group = window.active_group()
-	window.set_layout(layout)
+	window.run_command('set_layout', layout)
 	num_groups = len(layout['cells'])
 	window.focus_group(min(active_group, num_groups-1))
 
 def fixed_set_layout_no_focus_change(window, layout):
 	active_group = window.active_group()
-	window.set_layout(layout)
+	window.run_command('set_layout', layout)
 
 class WithSettings:
 	_settings = None


### PR DESCRIPTION
This change is needed for alkuzad/CloseMinimapOnMultiView#1 to work. SublimeText3 sends events for each layout change but `window.set_layout` isn't. 

There is also SublimeTextIssues/Core#2144 for this missing event but it seems there is no easy fix as I thought before. Current problem is a result of inconsistency made in development by Jon and fix for that - even if can be made - is still not likely to change Window class behaviour.